### PR TITLE
ENYO-570

### DIFF
--- a/youtube/YouTube.js
+++ b/youtube/YouTube.js
@@ -8,13 +8,13 @@ enyo.kind({
 		isApiReady: false,
 		apiReady: function() {
 			enyo.YouTube.isApiReady = true;
-			enyo.Signals.send("ApiReady");
+			enyo.Signals.send("onApiReady");
 		},
 		url: "http://gdata.youtube.com/feeds/api/videos/",
 		search: function(inSearchText, inRelated) {
 			var url = this.url + (inRelated ? inSearchText + "/related" : "");
-			var params = {q: inRelated ? null : inSearchText, alt: "json", format: 5};
-			return new enyo.Ajax({url: url})
+			var params = {q: inRelated ? null : inSearchText, alt: "json-in-script", format: 5};
+			return new enyo.JsonpRequest({url: url})
 				.go(params)
 				.response(this, "processResponse")
 				;


### PR DESCRIPTION
Enyo 2.0: Support: youtube does not load on IE 9
Converted app to use JSONP. Loads video list from YouTube, but videos won't play in IE9 due to JavaScript error. Works in other browsers.
Console shows "Object doesn't support property 'loadVideoById'."
Also fixed enyo.Signals bug.

Ben: I'm checking this in since the original issue is fixed (use JSONP) an so that other people can look at the other issue (Videos not playing in IE). You might have the line ending issue with this check in also. Sorry about that. I changed my IDE's default settings so it should be good going forward.
