### PR TITLE
Make "end" for block and array nodes point to the end of the terminator

### DIFF
--- a/analyzer2/Parser.js
+++ b/analyzer2/Parser.js
@@ -59,6 +59,11 @@ enyo.kind({
 				else if (node.token == "[") {
 					node.kind = "array";
 					node.children = this.walk(it, node.kind);
+					if (it.value) {
+						node.end = it.value.end;
+					} else {
+						console.log("No end token for array?");
+					}
 				}
 				else if (inState == "expression" && node.token == "]") {
 					return nodes;
@@ -81,6 +86,11 @@ enyo.kind({
 				else if (node.token == "{") {
 					node.kind = "block";
 					node.children = this.walk(it, node.kind);
+					if (it.value) {
+						node.end = it.value.end;
+					} else {
+						console.log("No end token for block?");
+					}
 					if (inState == "expression" || inState == "function") {
 						// a block terminates an expression
 						nodes.push(node);


### PR DESCRIPTION
This works for Ares, and doesn't break api-tool, but there are two error cases while parsing Enyo.js source:
  layout/Node.js - has a /\* block comment immediately following a }
  enyo/ui/Scroller.js - has a block that ends as the very last token in the file

I'll check in a fix for those two cases, but wanted to to unblock further Ares work first. I suspect there's an pre-existing problem with not pushing back a token in some cases. 
