### PR TITLE
[#ENYO-887] Fixed: Code parser chokes on attached file

### DIFF
--- a/analyzer2/Documentor.js
+++ b/analyzer2/Documentor.js
@@ -143,9 +143,11 @@ enyo.kind({
 		if (nodes) {
 			var elts = [];
 			for (var i=0, n, v; n=nodes[i]; i++) {
-				v = this.walkValue(new Iterator(n.children));
-				if (v) {
-					elts.push(v);
+				if (n.children) {   // Skip nodes without children such as comments
+					v = this.walkValue(new Iterator(n.children));
+					if (v) {
+						elts.push(v);
+					}
 				}
 			}
 			obj.properties = elts;


### PR DESCRIPTION
The problem was occuring in case of comments in a components array

Enyo-DCO-1.0-Signed-off-by: Yves Del Medico yves.del-medico@hp.com
