### PR TITLE
Updating indexModule to create unique names by incorporating paths. The ...

### DIFF
--- a/analyzer2/Indexer.js
+++ b/analyzer2/Indexer.js
@@ -47,8 +47,8 @@ enyo.kind({
 	indexModule: function(inModule) {
 		// this object is type: "module"
 		inModule.type = "module";
-		// name this module
-		inModule.name = inModule.name || inModule.rawPath;
+		// name this module by incorporating the path so its unique
+		inModule.name = inModule.path? inModule.path.replace("lib/", ""): inModule.label + "/" + inModule.rawPath;
 		// parse module objects
 		inModule.objects = new Documentor(new Parser(new Lexer(inModule.code)));
 		// index module objects


### PR DESCRIPTION
...case for this here is to fix the issue in the api-tool around modules having the same name (but in different repos or directories) not being displayed.

Enyo-DCO-1.0-Signed-off-by: Steven Feaster steven.feaster@palm.com
