### PR TITLE
ENYO-1195: Added a function search() to analyzer2/Indexer.js which allows to filter and remap the elements generated by the parsing.

### DIFF
--- a/analyzer2/Indexer.js
+++ b/analyzer2/Indexer.js
@@ -12,6 +12,14 @@ enyo.kind({
 	findByTopic: function(inTopic) {
 		return Documentor.findByProperty(this.objects, "topic", inTopic);
 	},
+	/**
+		Creates a new array with all elements of _inArray_ that pass the test implemented by _inFunc_.
+		If _inContext_ is specified, _inFunc_ is called with _inContext_ as _this_.
+	*/
+	search: function(inFilterFn, inMapFn, inContext) {
+		var values = enyo.filter(this.objects, inFilterFn, inContext);
+		return enyo.map(values, inMapFn, inContext);
+	},
 	addModules: function(inModules) {
 		enyo.forEach(inModules, this.addModule, this);
 		// sort (?!)


### PR DESCRIPTION
This function replaces the previously added getFunctionList() and getKindList() functions that were not used and not generic enough.

Enyo-DCO-1.1-Signed-off-by: Yves Del Medico yves.del-medico@hp.com
