### PR TITLE
ENYO-3571: add function's block start/end information found in every function property given by the analyzer

### DIFF
--- a/analyzer2/Documentor.js
+++ b/analyzer2/Documentor.js
@@ -212,6 +212,7 @@ enyo.kind({
 		var node = it.value;
 		var obj = this.make("expression", node);
 		obj.commaTerminated = node.commaTerminated;
+		obj.block = {start: node.children[1].start, end: node.children[1].end};
 		obj['arguments'] = enyo.map(node.children[0].children, function(n) { return n.token; });
 		if (this.debug) {
 			this.logMethodExit(it);


### PR DESCRIPTION
Related JIRA: https://enyojs.atlassian.net/browse/ENYO-3571

Analyzer gives now function's block start/end information

Enyo-DCO-1.1-Signed-off-by: Vincent HERILIER vincent.herilier@hp.com
