### PR TITLE
Fix accidental skipping of post-closure tokens in analyzer

### DIFF
--- a/analyzer2/Documentor.js
+++ b/analyzer2/Documentor.js
@@ -25,10 +25,10 @@ enyo.kind({
 			if (node.kind == "comment") {
 				this.cook_comment(node.token);
 			}
-			else if (node.token == "enyo.kind" && it.future.kind == "association") {
+			else if (node.token == "enyo.kind" && it.future && it.future.kind == "association") {
 				obj = this.cook_kind(it);
 			}
-			else if (node.token == "enyo.singleton" && it.future.kind == "association") {
+			else if (node.token == "enyo.singleton" && it.future && it.future.kind == "association") {
 				obj = this.cook_singleton(it);
 			}
 			else if (node.kind == "assignment") {
@@ -50,7 +50,7 @@ enyo.kind({
 						objects = objects.concat(objs);
 					}
 					// skip the closure invocation [()] in the form where that follows parens
-					if (node.children.length == 1) {
+					if (node.children.length == 1 && it.future && it.future.kind == "association") {
 						it.next();
 					}
 				}


### PR DESCRIPTION
ENYO-3484 showed a problem with parsing the code in enyo.Router.  The
root cause was code added for handling Enyo kinds defined in closures
that was too optimistic. It assumed the token after a closure that was
inside an association was the invocation, when this was also being
triggered for closures defined in calls to enyo.ready.  This resulted
in the following /*_@public_/ pragma being eaten.

Also guarded two uses of node.future so code won't crash if you've
got a malformed source file.

Enyo-DCO-1.1-Signed-Off-By: Ben Combee (ben.combee@lge.com)
